### PR TITLE
Prepare child execute tree for map action types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,8 @@ class Execute {
             });
         }
 
-        if (_step.actionType === Execute.builtinActionType.CHILD_EXECUTION_TREE) {
+        if (_step.actionType === Execute.builtinActionType.CHILD_EXECUTION_TREE ||
+            (_step.actionType === Execute.builtinActionType.MAP && _step.action.executionTree)) {
             _step.action.executionTree = this.prepareExecutionTree(_step.action.executionTree);
         }
 


### PR DESCRIPTION
Using child `executionTree` in `map` actions are throwing error  `Cannot read property 'enable' of undefined`.